### PR TITLE
Fix TypeError when openrouter architecture values are lists and not strings, and exclude new redundant keys

### DIFF
--- a/llm_openrouter.py
+++ b/llm_openrouter.py
@@ -186,10 +186,12 @@ def register_commands(cli):
                 bits.append(f"  context_length: {model['context_length']:,}")
                 architecture = model.get("architecture", None)
                 if architecture:
-                    bits.append(
-                        f"  architecture: "
-                        + (" ".join(str(value) for value in architecture.values() if value))
-                    )
+                    arch_values = [
+                        str(value) for key, value in architecture.items() 
+                        # `modality` key is enough, exclude these others
+                        if value and key not in ["input_modalities", "output_modalities"]
+                    ]
+                    bits.append(f"  architecture: {' '.join(arch_values)}")
                 bits.append(f"  supports_schema: {model['supports_schema']}")
                 pricing = format_pricing(model["pricing"])
                 if pricing:

--- a/llm_openrouter.py
+++ b/llm_openrouter.py
@@ -188,7 +188,7 @@ def register_commands(cli):
                 if architecture:
                     bits.append(
                         f"  architecture: "
-                        + (" ".join(value for value in architecture.values() if value))
+                        + (" ".join(str(value) for value in architecture.values() if value))
                     )
                 bits.append(f"  supports_schema: {model['supports_schema']}")
                 pricing = format_pricing(model["pricing"])


### PR DESCRIPTION
fixes #31 by converting to a string, but also excludes the new redundant `"input_modalities"` and `"output_modalities"` keys since `"modality"` already has the same info in a text friendly format.

Example output with this PR:

```
- id: tokyotech-llm/llama-3.1-swallow-8b-instruct-v0.3
  name: Swallow: Llama 3.1 Swallow 8B Instruct V0.3
  context_length: 16,384
  architecture: text->text Llama3
  supports_schema: False
  pricing: prompt $0.1/M, completion $0.2/M
```


Example output without excluding these keys:
```
- id: tokyotech-llm/llama-3.1-swallow-8b-instruct-v0.3
  name: Swallow: Llama 3.1 Swallow 8B Instruct V0.3
  context_length: 16,384
  architecture: text->text ['text'] ['text'] Llama3
  supports_schema: False
  pricing: prompt $0.1/M, completion $0.2/M
```

example output without this fix at all 😇:
```
...
  File "/Users/chris/.pyenv/versions/3.12.2/lib/python3.12/site-packages/llm_openrouter.py", line 194, in models
    bits.append(f"  architecture: {' '.join(arch_values)}")
                                   ^^^^^^^^^^^^^^^^^^^^^
TypeError: sequence item 1: expected str instance, list found
```
