### PR TITLE
feat: Add support for saved model configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,35 @@ You can inspect a different key by passing the key itself - or the name of the k
 llm openrouter key --key sk-xxx
 ```
 
+### Saved Configurations
+
+`llm-openrouter` now supports saving model configurations with specific options under aliases. This allows you to quickly reuse configurations without specifying options every time.
+
+To save a configuration:
+```bash
+llm openrouter save openrouter/meta-llama/llama-4-scout \
+    --name scout-groq-online \
+    -o provider '{"order":["Groq"],"allow_fallbacks":true}' \
+    -o online 1
+```
+
+To use:
+```bash
+llm -m scout-groq-online "what is the knowledge cutoff date of 'gemini-2.5'"
+```
+> According to [x.com](https://x.com/ForrestPKnight/status/1905371920159088834), the training data cut off for Gemini 2.5 Pro is March 2025. 
+
+
+To list saved configurations:
+```bash
+llm openrouter list-saved
+```
+
+To remove a saved configuration:
+```bash
+llm openrouter remove-saved mistral-groq
+```
+
 ## Development
 
 To set up this plugin locally, first checkout the code. Then create a new virtual environment:

--- a/llm_openrouter.py
+++ b/llm_openrouter.py
@@ -3,10 +3,94 @@ import llm
 from llm.default_plugins.openai_models import Chat, AsyncChat
 from pathlib import Path
 from pydantic import Field, field_validator
-from typing import Optional, Union
+from typing import Optional, Union, Dict, Any, List
 import json
 import time
 import httpx
+import sqlite_utils
+
+
+# --- Database Setup for Saved Configurations ---
+
+def get_db_path() -> Path:
+    """Returns the path to the SQLite database for saved configs."""
+    dir_path = llm.user_dir() / "openrouter_saved_configs"
+    dir_path.mkdir(parents=True, exist_ok=True)
+    return dir_path / "logs.db"
+
+def get_db() -> sqlite_utils.Database:
+    """Returns a sqlite_utils Database instance."""
+    return sqlite_utils.Database(get_db_path())
+
+def _ensure_table_exists(db: sqlite_utils.Database):
+    """Ensures the saved_configs table exists."""
+    if "saved_configs" not in db.table_names():
+        db["saved_configs"].create(
+            {
+                "alias": str,
+                "base_model_id": str,
+                "options": str, # JSON serialized options
+                "created_at": str,
+            },
+            pk="alias",
+        )
+
+def save_config(alias: str, base_model_id: str, options: Dict[str, Any]):
+    """Saves a configuration alias to the database."""
+    db = get_db()
+    _ensure_table_exists(db)
+    db["saved_configs"].insert(
+        {
+            "alias": alias,
+            "base_model_id": base_model_id,
+            "options": json.dumps(options),
+            "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+        },
+        replace=True,
+    )
+
+def get_config(alias: str) -> Optional[Dict[str, Any]]:
+    """Retrieves a saved configuration by alias."""
+    db = get_db()
+    _ensure_table_exists(db)
+    try:
+        row = db["saved_configs"].get(alias)
+        return {
+            "alias": row["alias"],
+            "base_model_id": row["base_model_id"],
+            "options": json.loads(row["options"]),
+            "created_at": row["created_at"],
+        }
+    except sqlite_utils.db.NotFoundError:
+        return None
+    except json.JSONDecodeError:
+        return None
+
+def list_configs() -> List[Dict[str, Any]]:
+    """Lists all saved configurations."""
+    db = get_db()
+    _ensure_table_exists(db)
+    configs = []
+    for row in db["saved_configs"].rows:
+        try:
+            configs.append({
+                "alias": row["alias"],
+                "base_model_id": row["base_model_id"],
+                "options": json.loads(row["options"]),
+                "created_at": row["created_at"],
+            })
+        except json.JSONDecodeError:
+            continue
+    return configs
+
+def remove_config(alias: str):
+    """Removes a saved configuration by alias."""
+    db = get_db()
+    _ensure_table_exists(db)
+    table = db["saved_configs"]
+    if table.count_where("alias = ?", [alias]) == 0:
+        raise sqlite_utils.db.NotFoundError(f"Alias '{alias}' not found.")
+    table.delete(alias)
 
 
 def get_openrouter_models():
@@ -30,6 +114,7 @@ def get_openrouter_models():
 
 
 class _mixin:
+    _saved_options: Optional[Dict[str, Any]] = None
     class Options(Chat.Options):
         online: Optional[bool] = Field(
             description="Use relevant search results from Exa",
@@ -52,17 +137,39 @@ class _mixin:
                     raise ValueError("Invalid JSON in provider string")
             return provider
 
+    def __init__(self, *args, saved_options: Optional[Dict[str, Any]] = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._saved_options = saved_options or {}
+
     def build_kwargs(self, prompt, stream):
         kwargs = super().build_kwargs(prompt, stream)
+        combined_options = self._saved_options.copy() if self._saved_options else {}
+        if prompt.options.online is not None:
+            combined_options['online'] = prompt.options.online
+        if prompt.options.provider is not None:
+            combined_options['provider'] = prompt.options.provider
+            
+        extra_body = {}
+        if combined_options.get("online"):
+            extra_body["plugins"] = [{"id": "web"}]
+        if combined_options.get("provider"):
+            provider_val = combined_options["provider"]
+            if isinstance(provider_val, str):
+                try:
+                    provider_val = json.loads(provider_val)
+                except json.JSONDecodeError:
+                    provider_val = None
+
+            if isinstance(provider_val, dict):
+                extra_body["provider"] = provider_val
+
         kwargs.pop("provider", None)
         kwargs.pop("online", None)
-        extra_body = {}
-        if prompt.options.online:
-            extra_body["plugins"] = [{"id": "web"}]
-        if prompt.options.provider:
-            extra_body["provider"] = prompt.options.provider
+
         if extra_body:
-            kwargs["extra_body"] = extra_body
+            existing_extra = kwargs.get("extra_body", {})
+            kwargs["extra_body"] = {**existing_extra, **extra_body}
+            
         return kwargs
 
 
@@ -88,6 +195,9 @@ def register_models(register):
     key = llm.get_key("", "openrouter", "OPENROUTER_KEY")
     if not key:
         return
+
+    registered_base_models = {}
+
     for model_definition in get_openrouter_models():
         supports_images = get_supports_images(model_definition)
         kwargs = dict(
@@ -98,10 +208,54 @@ def register_models(register):
             api_base="https://openrouter.ai/api/v1",
             headers={"HTTP-Referer": "https://llm.datasette.io/", "X-Title": "LLM"},
         )
+        
+        chat_model = OpenRouterChat(**kwargs)
+        async_chat_model = OpenRouterAsyncChat(**kwargs)
         register(
-            OpenRouterChat(**kwargs),
-            OpenRouterAsyncChat(**kwargs),
+            chat_model,
+            async_chat_model,
         )
+        registered_base_models[kwargs["model_id"]] = (chat_model, async_chat_model)
+    
+    saved_configs = list_configs()
+    
+    for config in saved_configs:
+        alias = config["alias"]
+        base_model_id = config["base_model_id"]
+        saved_options = config["options"]
+
+        if base_model_id in registered_base_models:
+            base_chat, base_async_chat = registered_base_models[base_model_id]
+
+            try:
+                alias_chat_model = OpenRouterChat(
+                    model_id=base_chat.model_id,
+                    model_name=base_chat.model_name,
+                    vision=getattr(base_chat,'vision', False),
+                    supports_schema=getattr(base_chat, 'supports_schema', False),
+                    api_base=base_chat.api_base,
+                    headers=base_chat.headers.copy(),
+                    saved_options=saved_options
+                )
+                alias_async_chat_model = OpenRouterAsyncChat(
+                     model_id=base_async_chat.model_id,
+                     model_name=base_async_chat.model_name,
+                     vision=getattr(base_async_chat, 'vision', False),
+                     supports_schema=getattr(base_async_chat, 'supports_schema', False),
+                     api_base=base_async_chat.api_base,
+                     headers=base_async_chat.headers.copy(),
+                     saved_options=saved_options
+                )
+
+                alias_chat_model.model_id = alias
+                alias_async_chat_model.model_id = alias
+
+                register(
+                    alias_chat_model,
+                    alias_async_chat_model
+                )
+            except Exception:
+                continue
 
 
 class DownloadError(Exception):
@@ -207,6 +361,76 @@ def register_commands(cli):
         )
         response.raise_for_status()
         click.echo(json.dumps(response.json()["data"], indent=2))
+
+    # New commands for saved configurations
+    @openrouter.command(name="save")
+    @click.argument("base_model_id")
+    @click.option("--name", "-n", required=True, help="Alias name for this configuration")
+    @click.option(
+        "-o",
+        "--option",
+        "options",
+        multiple=True,
+        nargs=2,
+        metavar="KEY VALUE",
+        help="Set an option (e.g., -o online true, -o provider '{\"order\":[\"Groq\"]}')",
+    )
+    def save_config_command(base_model_id, name, options):
+        """
+        Save a model configuration with specific options under an alias.
+
+        Example:
+
+        llm openrouter save openrouter/mistralai/mistral-7b-instruct \\
+            --name mistral-groq \\
+            -o provider '{"order":["Groq"],"allow_fallbacks":false}'
+        """
+        parsed_options = {}
+        for key, value in options:
+            if value.lower() == 'true':
+                parsed_value = True
+            elif value.lower() == 'false':
+                parsed_value = False
+            else:
+                parsed_value = value
+            parsed_options[key] = parsed_value
+
+        try:
+            save_config(name, base_model_id, parsed_options)
+            click.echo(f"Configuration '{name}' saved for model '{base_model_id}' with options: {json.dumps(parsed_options)}")
+        except Exception as e:
+            raise click.ClickException(f"Error saving configuration: {e}")
+
+    @openrouter.command(name="list-saved")
+    def list_saved_configs_command():
+        """List all saved OpenRouter model configuration aliases."""
+        try:
+            configs = list_configs()
+            if not configs:
+                click.echo("No saved configurations found.")
+                return
+
+            click.echo("Saved OpenRouter configurations:")
+            for config in configs:
+                click.echo(f"- Alias: {config['alias']}")
+                click.echo(f"  Base Model: {config['base_model_id']}")
+                click.echo(f"  Options: {json.dumps(config['options'])}")
+                click.echo(f"  Created: {config['created_at']}")
+                click.echo()
+        except Exception as e:
+            raise click.ClickException(f"Error listing configurations: {e}")
+
+    @openrouter.command(name="remove-saved")
+    @click.argument("alias")
+    def remove_saved_config_command(alias):
+        """Remove a saved OpenRouter model configuration alias."""
+        try:
+            remove_config(alias)
+            click.echo(f"Configuration alias '{alias}' removed.")
+        except sqlite_utils.db.NotFoundError:
+            raise click.ClickException(f"Configuration alias '{alias}' not found.")
+        except Exception as e:
+            raise click.ClickException(f"Error removing configuration '{alias}': {e}")
 
 
 def format_price(key, price_str):


### PR DESCRIPTION
Implement persistent storage for OpenRouter model configurations using SQLite. This allows users to save specific combinations of model options (e.g., provider settings, online mode) under custom aliases for easy reuse.

Key changes:
- Introduce database functions (`save_config`, `get_config`, etc.) and schema for storing configurations.
- Add CLI commands `openrouter save`, `openrouter list-saved`, and `openrouter remove-saved` to manage saved aliases.
- Modify model registration to load saved configurations and register them as distinct models identifiable by their alias.
- Update model classes to apply saved options when building API requests, allowing prompt-specific options to override saved ones.
```bash
llm openrouter save openrouter/meta-llama/llama-4-scout \
    --name scout-groq-online \
    -o provider '{"order":["Groq"],"allow_fallbacks":true}' \
    -o online 1
```
To use:
```bash
llm -m scout-groq-online "what is the knowledge cutoff date of 'gemini-2.5'"
```
> According to [x.com](https://x.com/ForrestPKnight/status/1905371920159088834), the training data cut off for Gemini 2.5 Pro is March 2025. 

These can now be used in a consortium:
```bash
llm openrouter save openrouter/google/gemini-2.5-pro-preview-03-25 --name gemini-2.5-t0 -o provider '{                                                            
 "order": [
    "Google AI Studio"
  ],
"allow_fallbacks": false
}' -o temperature 0
llm openrouter save openrouter/google/gemini-2.5-pro-preview-03-25 --name gemini-2.5-t2 -o provider '{
  "order": [
    "Google AI Studio"
  ],
"allow_fallbacks": false
}' -o temperature 2
```
```bash
llm consortium save -m scout-groq-online -m gemini-2.5-t0 -m gemini-2.5-t2 \
--arbiter gemini-2.5-t0 \
groq-gemini-online
```
```
llm -m groq-gemini-online "Create a comprehensive UV cheatsheet. Highlight new UV features for 2024 and 2025 including a link to the announcement or docs."
```