### PR TITLE
Add web_search_engine option

### DIFF
--- a/llm_openrouter.py
+++ b/llm_openrouter.py
@@ -39,6 +39,11 @@ class ReasoningEffortEnum(str, Enum):
     high = "high"
 
 
+class WebSearchEngineEnum(str, Enum):
+    exa = "exa"
+    native = "native"
+
+
 class _mixin:
     class Options(Chat.Options):
         online: Optional[bool] = Field(
@@ -61,6 +66,10 @@ class _mixin:
             description="Set to true to enable reasoning with default parameters",
             default=None,
         )
+        web_search: Optional[WebSearchEngineEnum] = Field(
+            description='Web search engine: "exa" or "native"',
+            default=None,
+        )
 
         @field_validator("provider")
         def validate_provider(cls, provider):
@@ -81,9 +90,14 @@ class _mixin:
         kwargs.pop("reasoning_effort", None)
         kwargs.pop("reasoning_max_tokens", None)
         kwargs.pop("reasoning_enabled", None)
+        kwargs.pop("web_search", None)
         extra_body = {}
+        if prompt.options.online and prompt.options.web_search:
+            raise ValueError("Cannot use both 'online' and 'web_search' options")
         if prompt.options.online:
-            extra_body["plugins"] = [{"id": "web"}]
+            extra_body["plugins"] = [{"id": "web", "engine": "exa"}]
+        if prompt.options.web_search:
+            extra_body["plugins"] = [{"id": "web", "engine": prompt.options.web_search}]
         if prompt.options.provider:
             extra_body["provider"] = prompt.options.provider
         reasoning = {}

--- a/llm_openrouter.py
+++ b/llm_openrouter.py
@@ -66,7 +66,7 @@ class _mixin:
             description="Set to true to enable reasoning with default parameters",
             default=None,
         )
-        web_search: Optional[WebSearchEngineEnum] = Field(
+        web_search_engine: Optional[WebSearchEngineEnum] = Field(
             description='Web search engine: "exa" or "native"',
             default=None,
         )
@@ -90,14 +90,12 @@ class _mixin:
         kwargs.pop("reasoning_effort", None)
         kwargs.pop("reasoning_max_tokens", None)
         kwargs.pop("reasoning_enabled", None)
-        kwargs.pop("web_search", None)
+        kwargs.pop("web_search_engine", None)
         extra_body = {}
-        if prompt.options.online and prompt.options.web_search:
-            raise ValueError("Cannot use both 'online' and 'web_search' options")
         if prompt.options.online:
-            extra_body["plugins"] = [{"id": "web", "engine": "exa"}]
-        if prompt.options.web_search:
-            extra_body["plugins"] = [{"id": "web", "engine": prompt.options.web_search}]
+            extra_body["plugins"] = [{"id": "web"}]
+        if prompt.options.web_search_engine:
+            extra_body["plugins"] = [{"id": "web", "engine": prompt.options.web_search_engine}]
         if prompt.options.provider:
             extra_body["provider"] = prompt.options.provider
         reasoning = {}

--- a/tests/test_llm_openrouter.py
+++ b/tests/test_llm_openrouter.py
@@ -146,33 +146,33 @@ def test_tool_calls():
     )
 
 
-def test_web_search_native():
+def test_web_search_engine_native():
     model = llm.get_model("openrouter/openai/gpt-5")
     prompt = MagicMock()
-    prompt.options = model.Options(web_search="native")
+    prompt.options = model.Options(web_search_engine="native")
     kwargs = model.build_kwargs(prompt, stream=False)
     assert kwargs["extra_body"]["plugins"] == [{"id": "web", "engine": "native"}]
 
 
-def test_web_search_exa():
+def test_web_search_engine_exa():
     model = llm.get_model("openrouter/openai/gpt-5")
     prompt = MagicMock()
-    prompt.options = model.Options(web_search="exa")
+    prompt.options = model.Options(web_search_engine="exa")
     kwargs = model.build_kwargs(prompt, stream=False)
     assert kwargs["extra_body"]["plugins"] == [{"id": "web", "engine": "exa"}]
 
 
-def test_online_uses_exa_engine():
+def test_online():
     model = llm.get_model("openrouter/openai/gpt-5")
     prompt = MagicMock()
     prompt.options = model.Options(online=True)
     kwargs = model.build_kwargs(prompt, stream=False)
-    assert kwargs["extra_body"]["plugins"] == [{"id": "web", "engine": "exa"}]
+    assert kwargs["extra_body"]["plugins"] == [{"id": "web"}]
 
 
-def test_online_and_web_search_conflict():
+def test_online_and_web_search_engine_together():
     model = llm.get_model("openrouter/openai/gpt-5")
     prompt = MagicMock()
-    prompt.options = model.Options(online=True, web_search="native")
-    with pytest.raises(ValueError, match="Cannot use both"):
-        model.build_kwargs(prompt, stream=False)
+    prompt.options = model.Options(online=True, web_search_engine="native")
+    kwargs = model.build_kwargs(prompt, stream=False)
+    assert kwargs["extra_body"]["plugins"] == [{"id": "web", "engine": "native"}]

--- a/tests/test_llm_openrouter.py
+++ b/tests/test_llm_openrouter.py
@@ -3,6 +3,7 @@ import pytest
 from click.testing import CliRunner
 from inline_snapshot import snapshot
 from llm.cli import cli
+from unittest.mock import MagicMock
 
 TINY_PNG = (
     b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\xa6\x00\x00\x01\x1a"
@@ -143,3 +144,35 @@ def test_tool_calls():
             "model": "openai/gpt-4.1-mini",
         }
     )
+
+
+def test_web_search_native():
+    model = llm.get_model("openrouter/openai/gpt-5")
+    prompt = MagicMock()
+    prompt.options = model.Options(web_search="native")
+    kwargs = model.build_kwargs(prompt, stream=False)
+    assert kwargs["extra_body"]["plugins"] == [{"id": "web", "engine": "native"}]
+
+
+def test_web_search_exa():
+    model = llm.get_model("openrouter/openai/gpt-5")
+    prompt = MagicMock()
+    prompt.options = model.Options(web_search="exa")
+    kwargs = model.build_kwargs(prompt, stream=False)
+    assert kwargs["extra_body"]["plugins"] == [{"id": "web", "engine": "exa"}]
+
+
+def test_online_uses_exa_engine():
+    model = llm.get_model("openrouter/openai/gpt-5")
+    prompt = MagicMock()
+    prompt.options = model.Options(online=True)
+    kwargs = model.build_kwargs(prompt, stream=False)
+    assert kwargs["extra_body"]["plugins"] == [{"id": "web", "engine": "exa"}]
+
+
+def test_online_and_web_search_conflict():
+    model = llm.get_model("openrouter/openai/gpt-5")
+    prompt = MagicMock()
+    prompt.options = model.Options(online=True, web_search="native")
+    with pytest.raises(ValueError, match="Cannot use both"):
+        model.build_kwargs(prompt, stream=False)


### PR DESCRIPTION
Adds a new `web_search_engine` option that allows users to [explicitly choose ](https://openrouter.ai/docs/features/web-search#engine-selection)the web search engine: "native" (provider's built-in search) or "exa".

If none is provided (i.e. only "online"), default to "undefined" (which per the OpenRouter docs means that `native` is preferred if available, and otherwise `exa `is selected).

Note that `native` does not seem to be widely available, and in particular isn't anymore for the examples listed in the docs; I could only get it to accept `native` for `gpt-5`. Still, it allows figuring out which models support `native` in the first place without paying for an Exa search each time.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)