### PR TITLE
Support base url override via env var

### DIFF
--- a/llm_openrouter.py
+++ b/llm_openrouter.py
@@ -2,6 +2,7 @@ import click
 from enum import Enum
 import llm
 from llm.default_plugins.openai_models import Chat, AsyncChat
+import os
 from pathlib import Path
 from pydantic import Field, field_validator
 from typing import Optional, Union
@@ -10,9 +11,18 @@ import time
 import httpx
 
 
+DEFAULT_API_BASE = "https://openrouter.ai/api/v1"
+
+
+def get_api_base():
+    """Get the API base URL from environment or use the default."""
+    return os.environ.get("OPENROUTER_BASE_URL", DEFAULT_API_BASE)
+
+
 def get_openrouter_models():
+    api_base = get_api_base()
     models = fetch_cached_json(
-        url="https://openrouter.ai/api/v1/models",
+        url=f"{api_base}/models",
         path=llm.user_dir() / "openrouter_models.json",
         cache_timeout=3600,
     )["data"]
@@ -122,6 +132,7 @@ def register_models(register):
     key = llm.get_key("", "openrouter", "OPENROUTER_KEY")
     if not key:
         return
+    api_base = get_api_base()
     for model_definition in get_openrouter_models():
         supports_images = get_supports_images(model_definition)
         kwargs = dict(
@@ -130,7 +141,7 @@ def register_models(register):
             vision=supports_images,
             supports_schema=has_parameter(model_definition, "structured_outputs"),
             supports_tools=has_parameter(model_definition, "tools"),
-            api_base="https://openrouter.ai/api/v1",
+            api_base=api_base,
             headers={"HTTP-Referer": "https://llm.datasette.io/", "X-Title": "LLM"},
         )
         register(
@@ -230,8 +241,9 @@ def register_commands(cli):
     def key(key):
         "View information and rate limits for the current key"
         key = llm.get_key(key, "openrouter", "OPENROUTER_KEY")
+        api_base = get_api_base()
         response = httpx.get(
-            "https://openrouter.ai/api/v1/auth/key",
+            f"{api_base}/auth/key",
             headers={"Authorization": f"Bearer {key}"},
         )
         response.raise_for_status()

--- a/tests/test_llm_openrouter.py
+++ b/tests/test_llm_openrouter.py
@@ -4,6 +4,22 @@ from click.testing import CliRunner
 from inline_snapshot import snapshot
 from llm.cli import cli
 
+from llm_openrouter import DEFAULT_API_BASE, get_api_base
+
+
+def test_get_api_base_default(monkeypatch):
+    """Test that get_api_base returns default when env var is not set."""
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    assert get_api_base() == DEFAULT_API_BASE
+
+
+def test_get_api_base_custom(monkeypatch):
+    """Test that get_api_base respects OPENROUTER_BASE_URL env var."""
+    custom_url = "https://my-proxy.example.com/v1"
+    monkeypatch.setenv("OPENROUTER_BASE_URL", custom_url)
+    assert get_api_base() == custom_url
+
+
 TINY_PNG = (
     b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\xa6\x00\x00\x01\x1a"
     b"\x02\x03\x00\x00\x00\xe6\x99\xc4^\x00\x00\x00\tPLTE\xff\xff\xff"


### PR DESCRIPTION
This PR adds `OPENROUTER_BASE_URL` env var support

We centrally manage our api keys, and have a proxy set up to replace them dynamically on http requests to llm providers. This lib hardcodes the api url, which makes it hard to use this lib

Many lab sdks support overriding the api url via env var, e.g. [`ANTHROPIC_BASE_URL`](https://code.claude.com/docs/en/third-party-integrations#configure-proxies-and-gateways) and [`OPENAI_BASE_URL`](https://github.com/openai/openai-python/tree/main?tab=readme-ov-file#configuring-the-http-client). In `llm`, this does "just work" for direct openai & anthropic requests, but not openrouter